### PR TITLE
Namespace the related class index

### DIFF
--- a/src/Faker/ORM/Doctrine/EntityPopulator.php
+++ b/src/Faker/ORM/Doctrine/EntityPopulator.php
@@ -143,17 +143,26 @@ class EntityPopulator
                 }
             }
 
-            $index = 0;
-            $formatters[$assocName] = function ($inserted) use ($relatedClass, &$index, $unique, $optional) {
+            // Use an array so we can store one index per related class type.
+            $relatedClassIndex = [];
+
+            $formatters[$assocName] = function ($inserted) use ($relatedClass, &$relatedClassIndex, $unique, $optional) {
 
                 if (isset($inserted[$relatedClass])) {
                     if ($unique) {
                         $related = null;
+
+                        if (! isset($relatedClassIndex[$relatedClass])) {
+                            $relatedClassIndex[$relatedClass] = 0;
+                        }
+
+                        $index = $relatedClassIndex[$relatedClass];
+
                         if (isset($inserted[$relatedClass][$index]) || !$optional) {
                             $related = $inserted[$relatedClass][$index];
                         }
 
-                        $index++;
+                        $relatedClassIndex[$relatedClass]++;
 
                         return $related;
                     }

--- a/src/Faker/Provider/kk_KZ/Person.php
+++ b/src/Faker/Provider/kk_KZ/Person.php
@@ -209,14 +209,17 @@ class Person extends \Faker\Provider\Person
             $birthDate = DateTime::dateTimeBetween();
         }
 
-        $population = mt_rand(1000, 2000);
-        $century    = self::getCenturyByYear((int) $birthDate->format('Y'));
+        do {
+            $population = mt_rand(1000, 2000);
+            $century = self::getCenturyByYear((int) $birthDate->format('Y'));
 
-        $iin  = $birthDate->format('ymd');
-        $iin .= (string) self::$genderCenturyMap[$gender][$century];
-        $iin .= (string) $population;
+            $iin = $birthDate->format('ymd');
+            $iin .= (string) self::$genderCenturyMap[$gender][$century];
+            $iin .= (string) $population;
+            $checksum = self::checkSum($iin);
+        } while ($checksum === 10);
 
-        return  $iin . (string) self::checkSum($iin);
+        return $iin . (string) $checksum;
     }
 
     /**

--- a/src/Faker/Provider/pl_PL/Person.php
+++ b/src/Faker/Provider/pl_PL/Person.php
@@ -159,11 +159,12 @@ class Person extends \Faker\Provider\Person
         for ($i = 6; $i < $length; $i++) {
             $result[$i] = static::randomDigit();
         }
-        if ($sex == "M") {
-            $result[$length - 1] |= 1;
-        } elseif ($sex == "F") {
-            $result[$length - 1] ^= 1;
+
+        $result[$length - 1] |= 1;
+        if ($sex == "F") {
+            $result[$length - 1] -= 1;
         }
+
         $checksum = 0;
         for ($i = 0; $i < $length; $i++) {
             $checksum += $weights[$i] * $result[$i];

--- a/test/Faker/Provider/DateTimeTest.php
+++ b/test/Faker/Provider/DateTimeTest.php
@@ -236,7 +236,7 @@ class DateTimeTest extends TestCase
 
     public function testFixedSeedWithMaximumTimestamp()
     {
-        $max = '2018-03-01 12:00:00';
+        $max = '2118-03-01 12:00:00';
 
         mt_srand(1);
         $unixTime = DateTimeProvider::unixTime($max);

--- a/test/Faker/Provider/pl_PL/PersonTest.php
+++ b/test/Faker/Provider/pl_PL/PersonTest.php
@@ -89,7 +89,7 @@ class PersonTest extends TestCase
     public function testPeselCheckSum()
     {
         $pesel   = $this->faker->pesel();
-        $weights = [1, 3, 7, 9, 1, 3, 7, 9, 1, 3, 1];
+        $weights = array(1, 3, 7, 9, 1, 3, 7, 9, 1, 3, 1);
         $sum     = 0;
 
         foreach ($weights as $key => $weight) {

--- a/test/Faker/Provider/pl_PL/PersonTest.php
+++ b/test/Faker/Provider/pl_PL/PersonTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Faker\Provider\pl_PL;
+
+use DateTime;
+use Faker\Generator;
+use PHPUnit\Framework\TestCase;
+
+class PersonTest extends TestCase
+{
+    /**
+     * @var Generator
+     */
+    private $faker;
+
+    public function setUp()
+    {
+        $faker = new Generator();
+        $faker->addProvider(new Person($faker));
+        $this->faker = $faker;
+    }
+
+    public function testPeselLenght()
+    {
+        $pesel = $this->faker->pesel();
+
+        $this->assertEquals(11, strlen($pesel));
+    }
+
+    public function testPeselDate()
+    {
+        $date  = new DateTime('1990-01-01');
+        $pesel = $this->faker->pesel($date);
+
+        $this->assertEquals('90', substr($pesel, 0, 2));
+        $this->assertEquals('01', substr($pesel, 2, 2));
+        $this->assertEquals('01', substr($pesel, 4, 2));
+    }
+
+    public function testPeselDateWithYearAfter2000()
+    {
+        $date  = new DateTime('2001-01-01');
+        $pesel = $this->faker->pesel($date);
+
+        $this->assertEquals('01', substr($pesel, 0, 2));
+        $this->assertEquals('21', substr($pesel, 2, 2));
+        $this->assertEquals('01', substr($pesel, 4, 2));
+    }
+
+    public function testPeselDateWithYearAfter2100()
+    {
+        $date  = new DateTime('2101-01-01');
+        $pesel = $this->faker->pesel($date);
+
+        $this->assertEquals('01', substr($pesel, 0, 2));
+        $this->assertEquals('41', substr($pesel, 2, 2));
+        $this->assertEquals('01', substr($pesel, 4, 2));
+    }
+
+    public function testPeselDateWithYearAfter2200()
+    {
+        $date  = new DateTime('2201-01-01');
+        $pesel = $this->faker->pesel($date);
+
+        $this->assertEquals('01', substr($pesel, 0, 2));
+        $this->assertEquals('61', substr($pesel, 2, 2));
+        $this->assertEquals('01', substr($pesel, 4, 2));
+    }
+
+    public function testPeselDateWithYearBefore1900()
+    {
+        $date  = new DateTime('1801-01-01');
+        $pesel = $this->faker->pesel($date);
+
+        $this->assertEquals('01', substr($pesel, 0, 2));
+        $this->assertEquals('81', substr($pesel, 2, 2));
+        $this->assertEquals('01', substr($pesel, 4, 2));
+    }
+
+    public function testPeselSex()
+    {
+        $male   = $this->faker->pesel(null, 'M');
+        $female = $this->faker->pesel(null, 'F');
+
+        $this->assertEquals(1, $male[9] % 2);
+        $this->assertEquals(0, $female[9] % 2);
+    }
+
+    public function testPeselCheckSum()
+    {
+        $pesel   = $this->faker->pesel();
+        $weights = [1, 3, 7, 9, 1, 3, 7, 9, 1, 3, 1];
+        $sum     = 0;
+
+        foreach ($weights as $key => $weight) {
+            $sum += $pesel[$key] * $weight;
+        }
+
+        $this->assertEquals(0, $sum % 10);
+    }
+}


### PR DESCRIPTION
In the original implementation the related class index was shared between all related class types. This meant that when the index was incremented some available related classes were missed. This also tended to lead to an array out of bounds error. By name-spacing the index we can avoid these issues.

NOTE: I ran the unit tests before making any changes and `Faker\Test\Provider\DateTimeTest::testFixedSeedWithMaximumTimestamp` was already failing. After making this change this test is still the only one failing.